### PR TITLE
Add missing #include <vector>

### DIFF
--- a/lsplt/src/main/jni/include/lsplt.hpp
+++ b/lsplt/src/main/jni/include/lsplt.hpp
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 /// \namespace lsplt
 namespace lsplt {


### PR DESCRIPTION
lsplt.hpp utilizes std::vector but was missing the required #include <vector> header. This caused compilation errors when using bindgen tools due to unresolved references to std::vector